### PR TITLE
Bundle libzmq in jzmq JAR

### DIFF
--- a/build_complete.sh
+++ b/build_complete.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+if [ ! -n "$1" ]
+then
+  echo "Usage: build_complete /path/to/libzmq.so"
+  exit 1
+fi 
+
+LIB_FILE=`basename $1`
+
+# ensure argument is path to libzmq.so
+if [[ ! -r "$1" || "$LIB_FILE" != "libzmq.so" ]]
+then
+  echo "Usage: build_complete /path/to/libzmq.so"
+  exit 1
+fi
+
+PREFIX="`readlink -f $(dirname $1)/../`"
+echo "Using libzmq at: $PREFIX"
+
+# search for libzmq headers
+if [[ ! -r "$PREFIX/include/zmq.h" || ! -r "$PREFIX/include/zmq_utils.h" ]]
+then
+  echo "Unable to find libzmq headers at expected path: $PREFIX/include"
+  exit 1
+fi
+
+# run autogen.sh if needs be
+if [ ! -e "./configure" ]
+then
+  echo "Generating configure..."
+  ./autogen.sh
+fi
+
+# drop the first argument so we can pass all remaining args to configure
+shift
+
+# build the binaries and JAR
+./configure --with-zeromq="$PREFIX" "$@" && make && ln -fs $PREFIX/lib/libzmq.so* ./src/.libs/ && mvn verify
+

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,9 @@
 				<targetPath>NATIVE/${os.arch}/${os.name}</targetPath>
 				<directory>${basedir}/src/.libs</directory>
 				<includes>
+					<include>libzmq.so*</include>
+					<include>libzmq.dylib</include>
+					<include>libzmq.dll</include>
 					<include>libjzmq.so</include>
 					<include>libjzmq.dylib</include>
 					<include>libjzmq.dll</include>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 				<targetPath>NATIVE/${os.arch}/${os.name}</targetPath>
 				<directory>${basedir}/src/.libs</directory>
 				<includes>
-					<include>libzmq.so*</include>
+					<include>libzmq.so</include>
 					<include>libzmq.dylib</include>
 					<include>libzmq.dll</include>
 					<include>libjzmq.so</include>

--- a/src/org/zeromq/EmbeddedLibraryTools.java
+++ b/src/org/zeromq/EmbeddedLibraryTools.java
@@ -19,7 +19,10 @@ public class EmbeddedLibraryTools {
 	public static final boolean LOADED_EMBEDDED_LIBRARY;
 	
 	static {
-		LOADED_EMBEDDED_LIBRARY = loadEmbeddedLibrary();
+		// attempt to load bundled libzmq before reverting to system installed copy
+		loadEmbeddedLibrary("libzmq");
+
+		LOADED_EMBEDDED_LIBRARY = loadEmbeddedLibrary("libjzmq");
 	}
 	
 	public static String getCurrentPlatformIdentifier() {
@@ -90,7 +93,7 @@ public class EmbeddedLibraryTools {
 		}
 	}
 	
-	private static boolean loadEmbeddedLibrary() {
+	private static boolean loadEmbeddedLibrary(String name) {
 
 		boolean usingEmbedded = false;
 
@@ -100,7 +103,9 @@ public class EmbeddedLibraryTools {
 		StringBuilder url = new StringBuilder();
 		url.append("/NATIVE/");
 		url.append(getCurrentPlatformIdentifier());
-		url.append("/libjzmq.");    	
+		url.append("/");
+		url.append(name);
+		url.append(".");    	
 		URL nativeLibraryUrl = null;
 		// loop through extensions, stopping after finding first one
 		for (String ext : allowedExtensions) {
@@ -115,7 +120,7 @@ public class EmbeddedLibraryTools {
 
 			try {
 
-				final File libfile = File.createTempFile("libjzmq-", ".lib");
+				final File libfile = File.createTempFile(name + "-", ".lib");
 				libfile.deleteOnExit(); // just in case
 
 				final InputStream in = nativeLibraryUrl.openStream();


### PR DESCRIPTION
JZMQ currently has a system dependency on the exact build of libzmq used to build jzmq. Since we don't care about portability (all machines are Linux) we can just bundle libzmq in the JAR and load it as we do the native libjzmq wrapper.

This should resolve two problems:
- Requiring everyone to have zeromq installed on their machine, even just to build a project that depends on it.
- ABI mismatches between jzmq and libzmq. This is pretty insidious as we often won't be notified of this until application runtime.

Critics may notice that this allows applications to run a different version of zeromq to the build installed on application machines. In practice however, this shouldn't be a problem as the different versions we've deployed are usually different enough to have an ABI change requiring a project rebuild anyway.
